### PR TITLE
Add cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.1.0)
+
 project(cmake_wrapper)
 
 set(CMAKE_VERBOSE_MAKEFILE TRUE)


### PR DESCRIPTION
cmake_minimum_required was missing from the "cmake wrapper".
Not sure how this could have ever work?